### PR TITLE
feat: Add axum metrics layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,12 @@ opentelemetry-http = { version = "0.27.0", optional = true }
 reqwest = { version = "0.12.12", optional = true }
 reqwest-middleware = { version = "0.4.0", optional = true }
 
+# axum
+axum = { version = "^0.7.9", optional = true }
+tower-otel-http-metrics = { version = "0.10.0", features = [
+    "axum",
+], optional = true }
+
 [dev-dependencies]
 tokio = { version = "1.43.0", features = ["full"] }
 
@@ -38,6 +44,7 @@ reqwest-middleware = [
     "dep:reqwest-middleware",
     "dep:opentelemetry-http",
 ]
+axum = ["dep:axum", "dep:tower-otel-http-metrics"]
 
 [lints.rust]
 dead_code = "warn"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,26 @@ Router::new().layer(OtelAxumLayer::default())
 
 For adding metrics all that is needed is to make a trace with specific prefix. The documentation on how it works is [here](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/struct.MetricsLayer.html#usage)
 
-For adding metrics to axum servers see crates like [tower-otel-http-metrics](https://github.com/francoposa/tower-otel-http-metrics)
+Another option is to use directly the OpenTelemetry SDK for that. Examples to it can be found [here](https://github.com/open-telemetry/opentelemetry-rust/blob/main/examples/metrics-basic/src/main.rs)
+
+For convenience the function `add_metrics_layer` was added. This function adds an axum layer that makes metrics. To use this function the feature flag `axum` is needed. The layer is only added if the metrics exporting configuration is enabled.
+
+Here is an example of usage. Note that in this example the layer won't be added because the default `OtelConfig` is not set to export metrics.
+
+```rust
+#[tokio::main]
+async fn main() {
+  let config = Some(rust_telemetry::config::OtelConfig::default());
+  let app = Router::new().route("/", get("Test"));
+  let app = rust_telemetry::axum::add_metrics_layer(app, config);
+
+  let listener = tokio::net::TcpListener::bind("127.0.0.1:8000").await.unwrap();
+  let server = axum::serve(listener, app);
+  if let Err(err) = server.await {
+      eprintln!("server error: {}", err);
+  }
+}
+```
 
 ## Lints
 

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -1,0 +1,47 @@
+//! Module containing the function to add a metrics layer to axum
+use axum::routing::Router;
+
+use super::config::OtelConfig;
+
+/// Adds a layer to create metrics if the metrics exporting is enabled
+///
+/// Example
+///
+/// This example shows how to call the add_metrics_layer however, in this case,
+/// the layer is not added because the default OtelConfig has the metrics
+/// exporting disabled
+///
+/// ```rust
+/// use axum::routing::{get, Router};
+///
+/// #[tokio::main]
+/// async fn main() {
+/// 	let config = Some(rust_telemetry::config::OtelConfig::default());
+/// 	let app = Router::new().route("/", get("Test"));
+/// 	let app = rust_telemetry::axum::add_metrics_layer(app, config);
+///
+/// 	let listener =
+/// 		tokio::net::TcpListener::bind("127.0.0.1:8000").await.unwrap();
+/// 	let server = axum::serve(listener, app);
+/// }
+/// ```
+pub fn add_metrics_layer(router: Router, config: Option<OtelConfig>) -> Router {
+	let mut router = router;
+	if let Some(exporter) = config.and_then(|config| config.exporter) {
+		if exporter.metrics.is_some_and(|config| config.enabled) {
+			let global_meter =
+				opentelemetry::global::meter(Box::leak(exporter.service_name.into_boxed_str()));
+			router = match tower_otel_http_metrics::HTTPMetricsLayerBuilder::new()
+				.with_meter(global_meter)
+				.build()
+			{
+				Ok(layer) => router.layer(layer),
+				Err(e) => {
+					tracing::warn!("Error creating metrics layer. {e:?}");
+					router
+				}
+			};
+		}
+	}
+	router
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ use tracing_subscriber::{
 };
 use url::Url;
 
+#[cfg(feature = "axum")]
+pub mod axum;
 pub mod config;
 #[cfg(feature = "reqwest-middleware")]
 pub mod reqwest_middleware;


### PR DESCRIPTION
Function to add the metrics layer from [tower-otel-http-metrics](https://github.com/francoposa/tower-otel-http-metrics) to the axum router if the metrics exporting is enabled