### PR TITLE
fix: Update variables for publish crate action

### DIFF
--- a/.github/workflows/rust-workflow.yml
+++ b/.github/workflows/rust-workflow.yml
@@ -47,8 +47,8 @@ jobs:
     needs: rust
     uses: famedly/backend-build-workflows/.github/workflows/publish-crate.yml@fcc2ec82a725d5c4c9c6a8f19e8df101c178dcb6
     with:
-      registry-name: "crates-io"
-      registry-index: "https://github.com/rust-lang/crates.io-index"
+      crate_registry_name: "crates-io"
+      crate_registry_index_url: "https://github.com/rust-lang/crates.io-index"
     secrets:
-      CI_SSH_PRIVATE_KEY: ${{ secrets.CI_SSH_PRIVATE_KEY }}
-      registry-auth-token: ${{ secrets.CRATES_IO_TOKEN }}
+      CRATE_REGISTRY_SSH_PRIVKEY: ${{ secrets.CI_SSH_PRIVATE_KEY }}
+      CRATE_REGISTRY_AUTH_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,10 +287,7 @@ pub enum OtelInitError {
 #[cfg(test)]
 mod tests {
 	#![allow(clippy::expect_used)]
-	use super::{
-		config::{ExporterConfig, OtelConfig, ProviderConfig},
-		init_otel,
-	};
+	use super::config::{ExporterConfig, OtelConfig, ProviderConfig};
 	use crate::config::StdoutLogsConfig;
 
 	#[tokio::test]


### PR DESCRIPTION
The variables had been changed, which was causing the CI job to fail. And the CI job isn't marked as required, so nobody noticed.