### PR TITLE
fix: Use doc_cfg instead of doc_auto_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! Lib containing the definitions and initializations of the OpenTelemetry
 //! tools
-#![cfg_attr(all(doc, not(doctest)), feature(doc_auto_cfg))]
+#![cfg_attr(all(doc, not(doctest), docsrs), feature(doc_cfg))]
 use std::{collections::BTreeMap as Map, str::FromStr as _};
 
 use config::{OtelConfig, OtelUrl, StdoutLogsConfig};


### PR DESCRIPTION
`doc_auto_cfg` was removed in rust 1.92.0, and is currently stopping from docs.rs from building (https://docs.rs/crate/rust-telemetry/1.3.0).

Using `doc_cfg` we get the same feature as `doc_auto_cfg` used to give us.

Also, hide this behind the `docsrs` configuration option, to stop absolutely depending on nightly features when building docs.

This commit will not cause docsrs to build rust-telemetry successfully. For this to work, we must update our dependencies (mostly transitive dependencies of OTEL, see #26) to newer versions that do not use `doc_auto_cfg` either.

But at least, if you depend on rust-telemetry you can now build `cargo doc` without it crashing.

# Testing

I built this on a nightly toolchain with `--all-features`, and removed the docsrs requirement to get the following:

<img width="1488" height="1230" alt="Screenshot 2026-06-25 at 09-55-17 rust_telemetry - Rust" src="https://github.com/user-attachments/assets/adf47513-0ef9-4cff-8e29-265990f47187" />

If I build rust-telemetry with the docsrs configuration option, it will fail because our dependencies still use `doc_auto_cfg`.

